### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ const findOne = require('feathers-findone')
 
 app.configure(findOne())
 ```
+Please note that you must configure *findOne* **before** any services are registered. 
 
 ## Use
 


### PR DESCRIPTION
Add a note mentioning that findOne must be configured before services are registered.

It took me a few minutes to get this working because I assumed it should be configured after services are registered. After consulting the source, I found that feathers-findone is being registered as a mixin, which must be registered prior to services in order to work correctly. 